### PR TITLE
Fixed column headings bug when downloading as csv

### DIFF
--- a/main.php
+++ b/main.php
@@ -2047,6 +2047,7 @@ function formHandler()
 							
 							array_splice($headers, $i + $_off, 1, $gps_flds);
 							$i = $i + 5;
+							$num_h += 5;
 						}
 					}
 


### PR DESCRIPTION
If there is a location field in the form then the last fields are not checked for being of type "location" or "gps" since the field count is not updated to reflect the added location fields.
